### PR TITLE
feat: hal i2c pcf8574 lcd demos

### DIFF
--- a/Examples/HAL/I2C/PCF8574_I2C_LCD/main.c
+++ b/Examples/HAL/I2C/PCF8574_I2C_LCD/main.c
@@ -1,0 +1,149 @@
+// This example was tested with 'PY32F030F28P6TU TSSOP20' chip
+
+#include "py32f0xx_hal_dma.h"
+#include "py32f0xx_hal_i2c.h"
+#include "py32f0xx_bsp_printf.h"
+
+#define I2C_ADDRESS        0xA0     /* host address */
+
+I2C_HandleTypeDef I2cHandle;
+
+void APP_ErrorHandler(void);
+static void APP_I2C_Config(void);
+
+#define SLAVE_ADDRESS_LCD 0x4E // PCF8574
+
+// LCD handling functions are borrowed from https://controllerstech.com/i2c-lcd-in-stm32/
+void lcd_send_cmd (char cmd)
+{
+  char data_u, data_l;
+  uint8_t data_t[4];
+  data_u = (cmd&0xf0);
+  data_l = ((cmd<<4)&0xf0);
+  data_t[0] = data_u|0x0C; // en=1, rs=0
+  data_t[1] = data_u|0x08; // en=0, rs=0
+  data_t[2] = data_l|0x0C; // en=1, rs=0
+  data_t[3] = data_l|0x08; // en=0, rs=0
+  HAL_I2C_Master_Transmit (&I2cHandle, SLAVE_ADDRESS_LCD,(uint8_t *) data_t, 4, 100);
+}
+
+void lcd_send_data (char data)
+{
+  char data_u, data_l;
+  uint8_t data_t[4];
+  data_u = (data&0xf0);
+  data_l = ((data<<4)&0xf0);
+  data_t[0] = data_u|0x0D; // en=1, rs=0
+  data_t[1] = data_u|0x09; // en=0, rs=0
+  data_t[2] = data_l|0x0D; // en=1, rs=0
+  data_t[3] = data_l|0x09; // en=0, rs=0
+  HAL_I2C_Master_Transmit (&I2cHandle, SLAVE_ADDRESS_LCD,(uint8_t *) data_t, 4, 100);
+}
+
+void lcd_clear (void)
+{
+  lcd_send_cmd (0x80);
+  for (int i=0; i<70; i++) {
+    lcd_send_data (' ');
+  }
+}
+
+void lcd_put_cur(int row, int col)
+{
+    switch (row) {
+        case 0:
+            col |= 0x80;
+            break;
+        case 1:
+            col |= 0xC0;
+            break;
+    }
+
+    lcd_send_cmd (col);
+}
+
+void lcd_init (void)
+{
+  // 4 bit initialisation
+  HAL_Delay(50); // wait for > 40ms
+  lcd_send_cmd (0x30);
+  HAL_Delay(5); // wait for > 4.1ms
+  lcd_send_cmd (0x30);
+  HAL_Delay(1); // wait for > 100us
+  lcd_send_cmd (0x30);
+  HAL_Delay(10);
+  lcd_send_cmd (0x20); // 4bit mode
+  HAL_Delay(10);
+
+  // display initialisation
+  lcd_send_cmd (0x28); // Function set --> DL=0 (4 bit mode), N = 1 (2 line display) F = 0 (5x8 characters)
+  HAL_Delay(1);
+  lcd_send_cmd (0x08); // Display on/off control --> D=0, C=0, B=0 ---> display off
+  HAL_Delay(1);
+  lcd_send_cmd (0x01); // clear display
+  HAL_Delay(1);
+  HAL_Delay(1);
+  lcd_send_cmd (0x06); // Entry mode set --> I/D = 1 (increment cursor) & S = 0 (no shift)
+  HAL_Delay(1);
+  lcd_send_cmd (0x0C); // Display on/off control --> D = 1, C and B = 0. (Cursor and blink, last two bits)
+}
+
+void lcd_send_string (char *str)
+{
+  while (*str) lcd_send_data (*str++);
+}
+
+int main(void)
+{
+  HAL_Init();
+
+  BSP_USART_Config();
+  printf("SystemClk:%ld\r\n", SystemCoreClock);
+
+  APP_I2C_Config();
+
+  lcd_init ();
+
+  lcd_send_string ("HELLO WORLD!");
+  HAL_Delay(1000);
+  lcd_put_cur(1, 0);
+  lcd_send_string("HOWDY!");
+  HAL_Delay(2000);
+
+  while(1);
+}
+
+static void APP_I2C_Config(void)
+{
+  I2cHandle.Instance             = I2C;
+  I2cHandle.Init.ClockSpeed      = 100000;        // 100KHz ~ 400KHz
+  I2cHandle.Init.DutyCycle       = I2C_DUTYCYCLE_16_9;
+  I2cHandle.Init.OwnAddress1     = I2C_ADDRESS;
+  I2cHandle.Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
+  I2cHandle.Init.NoStretchMode   = I2C_NOSTRETCH_DISABLE;
+  if (HAL_I2C_Init(&I2cHandle) != HAL_OK)
+  {
+    APP_ErrorHandler();
+  }
+}
+
+void APP_I2C_Transmit(uint8_t devAddress, uint8_t memAddress, uint8_t *pData, uint16_t len)
+{
+  HAL_I2C_Mem_Write(&I2cHandle, devAddress, memAddress, I2C_MEMADD_SIZE_8BIT, pData, len, 5000);
+}
+
+void APP_ErrorHandler(void)
+{
+  while (1);
+}
+
+#ifdef  USE_FULL_ASSERT
+/**
+  * @brief  Export assert error source and line number
+  */
+void assert_failed(uint8_t *file, uint32_t line)
+{
+  /* printf("Wrong parameters value: file %s on line %d\r\n", file, line) */
+  while (1);
+}
+#endif /* USE_FULL_ASSERT */

--- a/Examples/HAL/I2C/PCF8574_I2C_LCD/py32f0xx_hal_conf.h
+++ b/Examples/HAL/I2C/PCF8574_I2C_LCD/py32f0xx_hal_conf.h
@@ -1,0 +1,229 @@
+/**
+  ******************************************************************************
+  * @file    py32f0xx_hal_conf.h
+  * @author  MCU Application Team
+  * @brief   HAL configuration file.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) Puya Semiconductor Co.
+  * All rights reserved.</center></h2>
+  *
+  * <h2><center>&copy; Copyright (c) 2016 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __PY32F0xx_HAL_CONF_H
+#define __PY32F0xx_HAL_CONF_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+
+/* ########################## Module Selection ############################## */
+/**
+  * @brief This is the list of modules to be used in the HAL driver
+  */
+#define HAL_MODULE_ENABLED
+#define HAL_RCC_MODULE_ENABLED
+/* #define HAL_ADC_MODULE_ENABLED */
+/* #define HAL_CRC_MODULE_ENABLED */
+/* #define HAL_COMP_MODULE_ENABLED */
+#define HAL_FLASH_MODULE_ENABLED
+#define HAL_GPIO_MODULE_ENABLED
+/* #define HAL_IWDG_MODULE_ENABLED */
+/* #define HAL_WWDG_MODULE_ENABLED */
+#define HAL_TIM_MODULE_ENABLED
+#define HAL_DMA_MODULE_ENABLED
+/* #define HAL_LPTIM_MODULE_ENABLED */
+#define HAL_PWR_MODULE_ENABLED
+#define HAL_I2C_MODULE_ENABLED
+#define HAL_UART_MODULE_ENABLED
+/* #define HAL_SPI_MODULE_ENABLED */
+/* #define HAL_RTC_MODULE_ENABLED */
+/* #define HAL_LED_MODULE_ENABLED */
+/* #define HAL_EXTI_MODULE_ENABLED */
+#define HAL_CORTEX_MODULE_ENABLED
+
+/* ########################## Oscillator Values adaptation ####################*/
+
+#if !defined  (HSI_VALUE)
+  #define HSI_VALUE              ((uint32_t)8000000)     /*!< Value of the Internal oscillator in Hz */
+#endif /* HSI_VALUE */
+
+/**
+  * @brief Adjust the value of External High Speed oscillator (HSE) used in your application.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  */
+#if !defined  (HSE_VALUE)
+  #define HSE_VALUE              ((uint32_t)24000000) /*!< Value of the External oscillator in Hz */
+#endif /* HSE_VALUE */
+
+#if !defined  (HSE_STARTUP_TIMEOUT)
+  #define HSE_STARTUP_TIMEOUT    ((uint32_t)200)   /*!< Time out for HSE start up, in ms */
+#endif /* HSE_STARTUP_TIMEOUT */
+
+/**
+  * @brief Internal Low Speed Internal oscillator (LSI) value.
+  */
+#if !defined  (LSI_VALUE)
+ #define LSI_VALUE               ((uint32_t)32768)    /*!< LSI Typical Value in Hz */
+#endif /* LSI_VALUE */                               /*!< Value of the Internal Low Speed oscillator in Hz
+                                                     The real value may vary depending on the variations
+                                                     in voltage and temperature. */
+
+/**
+  * @brief Adjust the value of External Low Speed oscillator (LSE) used in your application.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  */
+#if !defined  (LSE_VALUE)
+  #define LSE_VALUE              ((uint32_t)32768) /*!< Value of the External oscillator in Hz*/
+#endif /* LSE_VALUE */
+
+#if !defined  (LSE_STARTUP_TIMEOUT)
+  #define LSE_STARTUP_TIMEOUT    ((uint32_t)5000)   /*!< Time out for LSE start up, in ms */
+#endif /* LSE_STARTUP_TIMEOUT */
+
+/* Tip: To avoid modifying this file each time you need to use different HSE,
+   ===  you can define the HSE value in your toolchain compiler preprocessor. */
+
+/* ########################### System Configuration ######################### */
+/**
+  * @brief This is the HAL system configuration section
+  */
+#define  VDD_VALUE               ((uint32_t)3300) /*!< Value of VDD in mv */
+#define  PRIORITY_HIGHEST        0
+#define  PRIORITY_HIGH           1
+#define  PRIORITY_LOW            2
+#define  PRIORITY_LOWEST         3
+#define  TICK_INT_PRIORITY       ((uint32_t)PRIORITY_LOWEST)    /*!< tick interrupt priority (lowest by default)  */
+#define  USE_RTOS                0
+#define  PREFETCH_ENABLE         0
+
+/* ########################## Assert Selection ############################## */
+/**
+  * @brief Uncomment the line below to expanse the "assert_param" macro in the
+  *        HAL drivers code
+  */
+/* #define USE_FULL_ASSERT       1U */
+
+
+/* Includes ------------------------------------------------------------------*/
+/**
+  * @brief Include module's header file
+  */
+#ifdef HAL_MODULE_ENABLED
+ #include "py32f0xx_hal.h"
+#endif /* HAL_MODULE_ENABLED */
+
+#ifdef HAL_RCC_MODULE_ENABLED
+ #include "py32f0xx_hal_rcc.h"
+#endif /* HAL_RCC_MODULE_ENABLED */
+
+#ifdef HAL_EXTI_MODULE_ENABLED
+ #include "py32f0xx_hal_exti.h"
+#endif /* HAL_EXTI_MODULE_ENABLED */
+
+#ifdef HAL_GPIO_MODULE_ENABLED
+ #include "py32f0xx_hal_gpio.h"
+#endif /* HAL_GPIO_MODULE_ENABLED */
+
+#ifdef HAL_CORTEX_MODULE_ENABLED
+ #include "py32f0xx_hal_cortex.h"
+#endif /* HAL_CORTEX_MODULE_ENABLED */
+
+#ifdef HAL_DMA_MODULE_ENABLED
+  #include "py32f0xx_hal_dma.h"
+#endif /* HAL_DMA_MODULE_ENABLED */
+
+#ifdef HAL_ADC_MODULE_ENABLED
+ #include "py32f0xx_hal_adc.h"
+#endif /* HAL_ADC_MODULE_ENABLED */
+
+#ifdef HAL_CRC_MODULE_ENABLED
+ #include "py32f0xx_hal_crc.h"
+#endif /* HAL_CRC_MODULE_ENABLED */
+
+#ifdef HAL_COMP_MODULE_ENABLED
+#include "py32f0xx_hal_comp.h"
+#endif /* HAL_COMP_MODULE_ENABLED */
+
+#ifdef HAL_FLASH_MODULE_ENABLED
+ #include "py32f0xx_hal_flash.h"
+#endif /* HAL_FLASH_MODULE_ENABLED */
+
+#ifdef HAL_I2C_MODULE_ENABLED
+ #include "py32f0xx_hal_i2c.h"
+#endif /* HAL_I2C_MODULE_ENABLED */
+
+#ifdef HAL_IWDG_MODULE_ENABLED
+ #include "py32f0xx_hal_iwdg.h"
+#endif /* HAL_IWDG_MODULE_ENABLED */
+
+#ifdef HAL_PWR_MODULE_ENABLED
+ #include "py32f0xx_hal_pwr.h"
+#endif /* HAL_PWR_MODULE_ENABLED */
+
+#ifdef HAL_RTC_MODULE_ENABLED
+ #include "py32f0xx_hal_rtc.h"
+#endif /* HAL_RTC_MODULE_ENABLED */
+
+#ifdef HAL_SPI_MODULE_ENABLED
+ #include "py32f0xx_hal_spi.h"
+#endif /* HAL_SPI_MODULE_ENABLED */
+
+#ifdef HAL_TIM_MODULE_ENABLED
+ #include "py32f0xx_hal_tim.h"
+#endif /* HAL_TIM_MODULE_ENABLED */
+
+#ifdef HAL_LPTIM_MODULE_ENABLED
+ #include "py32f0xx_hal_lptim.h"
+#endif /* HAL_LPTIM_MODULE_ENABLED */
+
+#ifdef HAL_UART_MODULE_ENABLED
+ #include "py32f0xx_hal_uart.h"
+#endif /* HAL_UART_MODULE_ENABLED */
+
+#ifdef HAL_WWDG_MODULE_ENABLED
+ #include "py32f0xx_hal_wwdg.h"
+#endif /* HAL_WWDG_MODULE_ENABLED */
+
+#ifdef HAL_USART_MODULE_ENABLED
+ #include "py32f0xx_hal_usart.h"
+#endif /* HAL_USART_MODULE_ENABLED */
+
+/* Exported macro ------------------------------------------------------------*/
+#ifdef  USE_FULL_ASSERT
+/**
+  * @brief  The assert_param macro is used for function's parameters check.
+  * @param  expr: If expr is false, it calls assert_failed function
+  *         which reports the name of the source file and the source
+  *         line number of the call that failed.
+  *         If expr is true, it returns no value.
+  * @retval None
+  */
+  #define assert_param(expr) ((expr) ? (void)0U : assert_failed((uint8_t *)__FILE__, __LINE__))
+/* Exported functions ------------------------------------------------------- */
+  void assert_failed(uint8_t* file, uint32_t line);
+#else
+  #define assert_param(expr) ((void)0U)
+#endif /* USE_FULL_ASSERT */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __PY32F0xx_HAL_CONF_H */
+
+/************************ (C) COPYRIGHT Puya *****END OF FILE******************/

--- a/Examples/HAL/I2C/PCF8574_I2C_LCD/py32f0xx_hal_msp.c
+++ b/Examples/HAL/I2C/PCF8574_I2C_LCD/py32f0xx_hal_msp.c
@@ -1,0 +1,66 @@
+/**
+  ******************************************************************************
+  * @file    py32f0xx_hal_msp.c
+  * @author  MCU Application Team
+  * @brief   This file provides code for the MSP Initialization
+  *          and de-Initialization codes.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) Puya Semiconductor Co.
+  * All rights reserved.</center></h2>
+  *
+  * <h2><center>&copy; Copyright (c) 2016 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "py32f0xx_hal.h"
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* External functions --------------------------------------------------------*/
+
+/**
+  * @brief  Configure the Flash prefetch and the Instruction cache,
+  *         the time base source, NVIC and any required global low level hardware
+  *         by calling the HAL_MspInit() callback function from HAL_Init()
+  *
+  */
+void HAL_MspInit(void)
+{
+}
+
+void HAL_I2C_MspInit(I2C_HandleTypeDef *hi2c)
+{
+  GPIO_InitTypeDef GPIO_InitStruct;
+
+  __HAL_RCC_I2C_CLK_ENABLE();
+  __HAL_RCC_GPIOF_CLK_ENABLE();
+
+  /**
+  PF1     ------> I2C1_SCL
+  PF0     ------> I2C1_SDA
+  */
+  GPIO_InitStruct.Pin = GPIO_PIN_1 | GPIO_PIN_0;
+  GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
+  GPIO_InitStruct.Pull = GPIO_PULLUP;
+  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+  GPIO_InitStruct.Alternate = GPIO_AF12_I2C;
+  HAL_GPIO_Init(GPIOF, &GPIO_InitStruct);
+
+  __HAL_RCC_I2C_FORCE_RESET();
+  __HAL_RCC_I2C_RELEASE_RESET();
+}
+
+/************************ (C) COPYRIGHT Puya *****END OF FILE******************/

--- a/Examples/HAL/I2C/PCF8574_I2C_LCD/py32f0xx_it.c
+++ b/Examples/HAL/I2C/PCF8574_I2C_LCD/py32f0xx_it.c
@@ -1,0 +1,85 @@
+/**
+  ******************************************************************************
+  * @file    py32f0xx_it.c
+  * @author  MCU Application Team
+  * @brief   Interrupt Service Routines.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) Puya Semiconductor Co.
+  * All rights reserved.</center></h2>
+  *
+  * <h2><center>&copy; Copyright (c) 2016 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "py32f0xx_hal.h"
+#include "py32f0xx_it.h"
+
+/* Private includes ----------------------------------------------------------*/
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private user code ---------------------------------------------------------*/
+/* External variables --------------------------------------------------------*/
+
+/******************************************************************************/
+/*          Cortex-M0+ Processor Interruption and Exception Handlers          */
+/******************************************************************************/
+/**
+  * @brief This function handles Non maskable interrupt.
+  */
+void NMI_Handler(void)
+{
+}
+
+/**
+  * @brief This function handles Hard fault interrupt.
+  */
+void HardFault_Handler(void)
+{
+  while (1)
+  {
+  }
+}
+
+/**
+  * @brief This function handles System service call via SWI instruction.
+  */
+void SVC_Handler(void)
+{
+}
+
+/**
+  * @brief This function handles Pendable request for system service.
+  */
+void PendSV_Handler(void)
+{
+}
+
+/**
+  * @brief This function handles System tick timer.
+  */
+void SysTick_Handler(void)
+{
+  HAL_IncTick();
+}
+
+/******************************************************************************/
+/* PY32F0xx Peripheral Interrupt Handlers                                     */
+/* Add here the Interrupt Handlers for the used peripherals.                  */
+/* For the available peripheral interrupt handler names,                      */
+/* please refer to the startup file.                                          */
+/******************************************************************************/
+
+/************************ (C) COPYRIGHT Puya *****END OF FILE******************/

--- a/Examples/HAL/I2C/PCF8574_I2C_LCD/py32f0xx_it.h
+++ b/Examples/HAL/I2C/PCF8574_I2C_LCD/py32f0xx_it.h
@@ -1,0 +1,48 @@
+/**
+  ******************************************************************************
+  * @file    py32f0xx_it.h
+  * @author  MCU Application Team
+  * @brief   This file contains the headers of the interrupt handlers.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) Puya Semiconductor Co.
+  * All rights reserved.</center></h2>
+  *
+  * <h2><center>&copy; Copyright (c) 2016 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __PY32F0XX_IT_H
+#define __PY32F0XX_IT_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Private includes ----------------------------------------------------------*/
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+/* Exported macro ------------------------------------------------------------*/
+/* Exported functions prototypes ---------------------------------------------*/
+void NMI_Handler(void);
+void HardFault_Handler(void);
+void SVC_Handler(void);
+void PendSV_Handler(void);
+void SysTick_Handler(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __PY32F0XX_IT_H */
+
+/************************ (C) COPYRIGHT Puya *****END OF FILE******************/

--- a/Examples/HAL/I2C/PCF8574_I2C_LCD_F003_SOP16/README.md
+++ b/Examples/HAL/I2C/PCF8574_I2C_LCD_F003_SOP16/README.md
@@ -1,0 +1,33 @@
+Following `Makefile` changes are needed to run this example:
+
+```diff
+diff --git a/Makefile b/Makefile
+index 5c24b12..cca49c1 100644
+--- a/Makefile
++++ b/Makefile
+@@ -38,13 +38,13 @@ PYOCD_EXE           ?= pyocd
+ #   py32f003x4,  py32f003x6, py32f003x8,
+ #   py32f030x3,  py32f030x4, py32f030x6, py32f030x7, py32f030x8
+ #   py32f072xb
+-PYOCD_DEVICE   ?= py32f030x8
++PYOCD_DEVICE   ?= py32f003x6
+
+
+ ##### Paths ############
+
+ # Link descript file: py32f002x5.ld, py32f003x6.ld, py32f003x8.ld, py32f030x6.ld, py32f030x8.ld
+-LDSCRIPT               = Libraries/LDScripts/py32f030x8.ld
++LDSCRIPT               = Libraries/LDScripts/py32f003x6.ld
+ # Library build flags:
+ #   PY32F002x5, PY32F002Ax5,
+ #   PY32F003x4, PY32F003x6, PY32F003x8,
+@@ -61,7 +61,7 @@ CFILES :=
+ # ASM source folders
+ ADIRS  := User
+ # ASM single files
+-AFILES := Libraries/CMSIS/Device/PY32F0xx/Source/gcc/startup_py32f030.s
++AFILES := Libraries/CMSIS/Device/PY32F0xx/Source/gcc/startup_py32f003.s
+
+ # Include paths
+ INCLUDES       := Libraries/CMSIS/Core/Include \
+```

--- a/Examples/HAL/I2C/PCF8574_I2C_LCD_F003_SOP16/main.c
+++ b/Examples/HAL/I2C/PCF8574_I2C_LCD_F003_SOP16/main.c
@@ -1,0 +1,149 @@
+// This example was tested with 'PY32F003W16S6TU SOP16' chip
+
+#include "py32f0xx_hal_dma.h"
+#include "py32f0xx_hal_i2c.h"
+#include "py32f0xx_bsp_printf.h"
+
+#define I2C_ADDRESS        0xA0     /* host address */
+
+I2C_HandleTypeDef I2cHandle;
+
+void APP_ErrorHandler(void);
+static void APP_I2C_Config(void);
+
+#define SLAVE_ADDRESS_LCD 0x4E // PCF8574
+
+// LCD handling functions are borrowed from https://controllerstech.com/i2c-lcd-in-stm32/
+void lcd_send_cmd (char cmd)
+{
+  char data_u, data_l;
+  uint8_t data_t[4];
+  data_u = (cmd&0xf0);
+  data_l = ((cmd<<4)&0xf0);
+  data_t[0] = data_u|0x0C; // en=1, rs=0
+  data_t[1] = data_u|0x08; // en=0, rs=0
+  data_t[2] = data_l|0x0C; // en=1, rs=0
+  data_t[3] = data_l|0x08; // en=0, rs=0
+  HAL_I2C_Master_Transmit (&I2cHandle, SLAVE_ADDRESS_LCD,(uint8_t *) data_t, 4, 100);
+}
+
+void lcd_send_data (char data)
+{
+  char data_u, data_l;
+  uint8_t data_t[4];
+  data_u = (data&0xf0);
+  data_l = ((data<<4)&0xf0);
+  data_t[0] = data_u|0x0D; // en=1, rs=0
+  data_t[1] = data_u|0x09; // en=0, rs=0
+  data_t[2] = data_l|0x0D; // en=1, rs=0
+  data_t[3] = data_l|0x09; // en=0, rs=0
+  HAL_I2C_Master_Transmit (&I2cHandle, SLAVE_ADDRESS_LCD,(uint8_t *) data_t, 4, 100);
+}
+
+void lcd_clear (void)
+{
+  lcd_send_cmd (0x80);
+  for (int i=0; i<70; i++) {
+    lcd_send_data (' ');
+  }
+}
+
+void lcd_put_cur(int row, int col)
+{
+    switch (row) {
+        case 0:
+            col |= 0x80;
+            break;
+        case 1:
+            col |= 0xC0;
+            break;
+    }
+
+    lcd_send_cmd (col);
+}
+
+void lcd_init (void)
+{
+  // 4 bit initialisation
+  HAL_Delay(50); // wait for > 40ms
+  lcd_send_cmd (0x30);
+  HAL_Delay(5); // wait for > 4.1ms
+  lcd_send_cmd (0x30);
+  HAL_Delay(1); // wait for > 100us
+  lcd_send_cmd (0x30);
+  HAL_Delay(10);
+  lcd_send_cmd (0x20); // 4bit mode
+  HAL_Delay(10);
+
+  // display initialisation
+  lcd_send_cmd (0x28); // Function set --> DL=0 (4 bit mode), N = 1 (2 line display) F = 0 (5x8 characters)
+  HAL_Delay(1);
+  lcd_send_cmd (0x08); // Display on/off control --> D=0, C=0, B=0 ---> display off
+  HAL_Delay(1);
+  lcd_send_cmd (0x01); // clear display
+  HAL_Delay(1);
+  HAL_Delay(1);
+  lcd_send_cmd (0x06); // Entry mode set --> I/D = 1 (increment cursor) & S = 0 (no shift)
+  HAL_Delay(1);
+  lcd_send_cmd (0x0C); // Display on/off control --> D = 1, C and B = 0. (Cursor and blink, last two bits)
+}
+
+void lcd_send_string (char *str)
+{
+  while (*str) lcd_send_data (*str++);
+}
+
+int main(void)
+{
+  HAL_Init();
+
+  // BSP_USART_Config();
+  // printf("SystemClk:%ld\r\n", SystemCoreClock);
+
+  APP_I2C_Config();
+
+  lcd_init ();
+
+  lcd_send_string ("HELLO WORLD!");
+  HAL_Delay(1000);
+  lcd_put_cur(1, 0);
+  lcd_send_string("HOWDY!");
+  HAL_Delay(2000);
+
+  while(1);
+}
+
+static void APP_I2C_Config(void)
+{
+  I2cHandle.Instance             = I2C;
+  I2cHandle.Init.ClockSpeed      = 100000;        // 100KHz ~ 400KHz
+  I2cHandle.Init.DutyCycle       = I2C_DUTYCYCLE_16_9;
+  I2cHandle.Init.OwnAddress1     = I2C_ADDRESS;
+  I2cHandle.Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
+  I2cHandle.Init.NoStretchMode   = I2C_NOSTRETCH_DISABLE;
+  if (HAL_I2C_Init(&I2cHandle) != HAL_OK)
+  {
+    APP_ErrorHandler();
+  }
+}
+
+void APP_I2C_Transmit(uint8_t devAddress, uint8_t memAddress, uint8_t *pData, uint16_t len)
+{
+  HAL_I2C_Mem_Write(&I2cHandle, devAddress, memAddress, I2C_MEMADD_SIZE_8BIT, pData, len, 5000);
+}
+
+void APP_ErrorHandler(void)
+{
+  while (1);
+}
+
+#ifdef  USE_FULL_ASSERT
+/**
+  * @brief  Export assert error source and line number
+  */
+void assert_failed(uint8_t *file, uint32_t line)
+{
+  /* printf("Wrong parameters value: file %s on line %d\r\n", file, line) */
+  while (1);
+}
+#endif /* USE_FULL_ASSERT */

--- a/Examples/HAL/I2C/PCF8574_I2C_LCD_F003_SOP16/py32f0xx_hal_conf.h
+++ b/Examples/HAL/I2C/PCF8574_I2C_LCD_F003_SOP16/py32f0xx_hal_conf.h
@@ -1,0 +1,229 @@
+/**
+  ******************************************************************************
+  * @file    py32f0xx_hal_conf.h
+  * @author  MCU Application Team
+  * @brief   HAL configuration file.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) Puya Semiconductor Co.
+  * All rights reserved.</center></h2>
+  *
+  * <h2><center>&copy; Copyright (c) 2016 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __PY32F0xx_HAL_CONF_H
+#define __PY32F0xx_HAL_CONF_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+
+/* ########################## Module Selection ############################## */
+/**
+  * @brief This is the list of modules to be used in the HAL driver
+  */
+#define HAL_MODULE_ENABLED
+#define HAL_RCC_MODULE_ENABLED
+/* #define HAL_ADC_MODULE_ENABLED */
+/* #define HAL_CRC_MODULE_ENABLED */
+/* #define HAL_COMP_MODULE_ENABLED */
+#define HAL_FLASH_MODULE_ENABLED
+#define HAL_GPIO_MODULE_ENABLED
+/* #define HAL_IWDG_MODULE_ENABLED */
+/* #define HAL_WWDG_MODULE_ENABLED */
+#define HAL_TIM_MODULE_ENABLED
+#define HAL_DMA_MODULE_ENABLED
+/* #define HAL_LPTIM_MODULE_ENABLED */
+#define HAL_PWR_MODULE_ENABLED
+#define HAL_I2C_MODULE_ENABLED
+#define HAL_UART_MODULE_ENABLED
+/* #define HAL_SPI_MODULE_ENABLED */
+/* #define HAL_RTC_MODULE_ENABLED */
+/* #define HAL_LED_MODULE_ENABLED */
+/* #define HAL_EXTI_MODULE_ENABLED */
+#define HAL_CORTEX_MODULE_ENABLED
+
+/* ########################## Oscillator Values adaptation ####################*/
+
+#if !defined  (HSI_VALUE)
+  #define HSI_VALUE              ((uint32_t)8000000)     /*!< Value of the Internal oscillator in Hz */
+#endif /* HSI_VALUE */
+
+/**
+  * @brief Adjust the value of External High Speed oscillator (HSE) used in your application.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  */
+#if !defined  (HSE_VALUE)
+  #define HSE_VALUE              ((uint32_t)24000000) /*!< Value of the External oscillator in Hz */
+#endif /* HSE_VALUE */
+
+#if !defined  (HSE_STARTUP_TIMEOUT)
+  #define HSE_STARTUP_TIMEOUT    ((uint32_t)200)   /*!< Time out for HSE start up, in ms */
+#endif /* HSE_STARTUP_TIMEOUT */
+
+/**
+  * @brief Internal Low Speed Internal oscillator (LSI) value.
+  */
+#if !defined  (LSI_VALUE)
+ #define LSI_VALUE               ((uint32_t)32768)    /*!< LSI Typical Value in Hz */
+#endif /* LSI_VALUE */                               /*!< Value of the Internal Low Speed oscillator in Hz
+                                                     The real value may vary depending on the variations
+                                                     in voltage and temperature. */
+
+/**
+  * @brief Adjust the value of External Low Speed oscillator (LSE) used in your application.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  */
+#if !defined  (LSE_VALUE)
+  #define LSE_VALUE              ((uint32_t)32768) /*!< Value of the External oscillator in Hz*/
+#endif /* LSE_VALUE */
+
+#if !defined  (LSE_STARTUP_TIMEOUT)
+  #define LSE_STARTUP_TIMEOUT    ((uint32_t)5000)   /*!< Time out for LSE start up, in ms */
+#endif /* LSE_STARTUP_TIMEOUT */
+
+/* Tip: To avoid modifying this file each time you need to use different HSE,
+   ===  you can define the HSE value in your toolchain compiler preprocessor. */
+
+/* ########################### System Configuration ######################### */
+/**
+  * @brief This is the HAL system configuration section
+  */
+#define  VDD_VALUE               ((uint32_t)3300) /*!< Value of VDD in mv */
+#define  PRIORITY_HIGHEST        0
+#define  PRIORITY_HIGH           1
+#define  PRIORITY_LOW            2
+#define  PRIORITY_LOWEST         3
+#define  TICK_INT_PRIORITY       ((uint32_t)PRIORITY_LOWEST)    /*!< tick interrupt priority (lowest by default)  */
+#define  USE_RTOS                0
+#define  PREFETCH_ENABLE         0
+
+/* ########################## Assert Selection ############################## */
+/**
+  * @brief Uncomment the line below to expanse the "assert_param" macro in the
+  *        HAL drivers code
+  */
+/* #define USE_FULL_ASSERT       1U */
+
+
+/* Includes ------------------------------------------------------------------*/
+/**
+  * @brief Include module's header file
+  */
+#ifdef HAL_MODULE_ENABLED
+ #include "py32f0xx_hal.h"
+#endif /* HAL_MODULE_ENABLED */
+
+#ifdef HAL_RCC_MODULE_ENABLED
+ #include "py32f0xx_hal_rcc.h"
+#endif /* HAL_RCC_MODULE_ENABLED */
+
+#ifdef HAL_EXTI_MODULE_ENABLED
+ #include "py32f0xx_hal_exti.h"
+#endif /* HAL_EXTI_MODULE_ENABLED */
+
+#ifdef HAL_GPIO_MODULE_ENABLED
+ #include "py32f0xx_hal_gpio.h"
+#endif /* HAL_GPIO_MODULE_ENABLED */
+
+#ifdef HAL_CORTEX_MODULE_ENABLED
+ #include "py32f0xx_hal_cortex.h"
+#endif /* HAL_CORTEX_MODULE_ENABLED */
+
+#ifdef HAL_DMA_MODULE_ENABLED
+  #include "py32f0xx_hal_dma.h"
+#endif /* HAL_DMA_MODULE_ENABLED */
+
+#ifdef HAL_ADC_MODULE_ENABLED
+ #include "py32f0xx_hal_adc.h"
+#endif /* HAL_ADC_MODULE_ENABLED */
+
+#ifdef HAL_CRC_MODULE_ENABLED
+ #include "py32f0xx_hal_crc.h"
+#endif /* HAL_CRC_MODULE_ENABLED */
+
+#ifdef HAL_COMP_MODULE_ENABLED
+#include "py32f0xx_hal_comp.h"
+#endif /* HAL_COMP_MODULE_ENABLED */
+
+#ifdef HAL_FLASH_MODULE_ENABLED
+ #include "py32f0xx_hal_flash.h"
+#endif /* HAL_FLASH_MODULE_ENABLED */
+
+#ifdef HAL_I2C_MODULE_ENABLED
+ #include "py32f0xx_hal_i2c.h"
+#endif /* HAL_I2C_MODULE_ENABLED */
+
+#ifdef HAL_IWDG_MODULE_ENABLED
+ #include "py32f0xx_hal_iwdg.h"
+#endif /* HAL_IWDG_MODULE_ENABLED */
+
+#ifdef HAL_PWR_MODULE_ENABLED
+ #include "py32f0xx_hal_pwr.h"
+#endif /* HAL_PWR_MODULE_ENABLED */
+
+#ifdef HAL_RTC_MODULE_ENABLED
+ #include "py32f0xx_hal_rtc.h"
+#endif /* HAL_RTC_MODULE_ENABLED */
+
+#ifdef HAL_SPI_MODULE_ENABLED
+ #include "py32f0xx_hal_spi.h"
+#endif /* HAL_SPI_MODULE_ENABLED */
+
+#ifdef HAL_TIM_MODULE_ENABLED
+ #include "py32f0xx_hal_tim.h"
+#endif /* HAL_TIM_MODULE_ENABLED */
+
+#ifdef HAL_LPTIM_MODULE_ENABLED
+ #include "py32f0xx_hal_lptim.h"
+#endif /* HAL_LPTIM_MODULE_ENABLED */
+
+#ifdef HAL_UART_MODULE_ENABLED
+ #include "py32f0xx_hal_uart.h"
+#endif /* HAL_UART_MODULE_ENABLED */
+
+#ifdef HAL_WWDG_MODULE_ENABLED
+ #include "py32f0xx_hal_wwdg.h"
+#endif /* HAL_WWDG_MODULE_ENABLED */
+
+#ifdef HAL_USART_MODULE_ENABLED
+ #include "py32f0xx_hal_usart.h"
+#endif /* HAL_USART_MODULE_ENABLED */
+
+/* Exported macro ------------------------------------------------------------*/
+#ifdef  USE_FULL_ASSERT
+/**
+  * @brief  The assert_param macro is used for function's parameters check.
+  * @param  expr: If expr is false, it calls assert_failed function
+  *         which reports the name of the source file and the source
+  *         line number of the call that failed.
+  *         If expr is true, it returns no value.
+  * @retval None
+  */
+  #define assert_param(expr) ((expr) ? (void)0U : assert_failed((uint8_t *)__FILE__, __LINE__))
+/* Exported functions ------------------------------------------------------- */
+  void assert_failed(uint8_t* file, uint32_t line);
+#else
+  #define assert_param(expr) ((void)0U)
+#endif /* USE_FULL_ASSERT */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __PY32F0xx_HAL_CONF_H */
+
+/************************ (C) COPYRIGHT Puya *****END OF FILE******************/

--- a/Examples/HAL/I2C/PCF8574_I2C_LCD_F003_SOP16/py32f0xx_hal_msp.c
+++ b/Examples/HAL/I2C/PCF8574_I2C_LCD_F003_SOP16/py32f0xx_hal_msp.c
@@ -1,0 +1,64 @@
+/**
+  ******************************************************************************
+  * @file    py32f0xx_hal_msp.c
+  * @author  MCU Application Team
+  * @brief   This file provides code for the MSP Initialization
+  *          and de-Initialization codes.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) Puya Semiconductor Co.
+  * All rights reserved.</center></h2>
+  *
+  * <h2><center>&copy; Copyright (c) 2016 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "py32f0xx_hal.h"
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* External functions --------------------------------------------------------*/
+
+/**
+  * @brief  Configure the Flash prefetch and the Instruction cache,
+  *         the time base source, NVIC and any required global low level hardware
+  *         by calling the HAL_MspInit() callback function from HAL_Init()
+  *
+  */
+void HAL_MspInit(void)
+{
+}
+
+void HAL_I2C_MspInit(I2C_HandleTypeDef *hi2c)
+{
+  GPIO_InitTypeDef GPIO_InitStruct;
+
+  __HAL_RCC_I2C_CLK_ENABLE();
+  __HAL_RCC_GPIOA_CLK_ENABLE();
+
+  // PF1 ------> I2C1_SCL
+  // PF0 ------> I2C1_SDA
+  GPIO_InitStruct.Pin = GPIO_PIN_2 | GPIO_PIN_3;
+  GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
+  GPIO_InitStruct.Pull = GPIO_PULLUP;
+  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+  GPIO_InitStruct.Alternate = GPIO_AF12_I2C;
+  HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+  __HAL_RCC_I2C_FORCE_RESET();
+  __HAL_RCC_I2C_RELEASE_RESET();
+}
+
+/************************ (C) COPYRIGHT Puya *****END OF FILE******************/

--- a/Examples/HAL/I2C/PCF8574_I2C_LCD_F003_SOP16/py32f0xx_it.c
+++ b/Examples/HAL/I2C/PCF8574_I2C_LCD_F003_SOP16/py32f0xx_it.c
@@ -1,0 +1,85 @@
+/**
+  ******************************************************************************
+  * @file    py32f0xx_it.c
+  * @author  MCU Application Team
+  * @brief   Interrupt Service Routines.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) Puya Semiconductor Co.
+  * All rights reserved.</center></h2>
+  *
+  * <h2><center>&copy; Copyright (c) 2016 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "py32f0xx_hal.h"
+#include "py32f0xx_it.h"
+
+/* Private includes ----------------------------------------------------------*/
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private user code ---------------------------------------------------------*/
+/* External variables --------------------------------------------------------*/
+
+/******************************************************************************/
+/*          Cortex-M0+ Processor Interruption and Exception Handlers          */
+/******************************************************************************/
+/**
+  * @brief This function handles Non maskable interrupt.
+  */
+void NMI_Handler(void)
+{
+}
+
+/**
+  * @brief This function handles Hard fault interrupt.
+  */
+void HardFault_Handler(void)
+{
+  while (1)
+  {
+  }
+}
+
+/**
+  * @brief This function handles System service call via SWI instruction.
+  */
+void SVC_Handler(void)
+{
+}
+
+/**
+  * @brief This function handles Pendable request for system service.
+  */
+void PendSV_Handler(void)
+{
+}
+
+/**
+  * @brief This function handles System tick timer.
+  */
+void SysTick_Handler(void)
+{
+  HAL_IncTick();
+}
+
+/******************************************************************************/
+/* PY32F0xx Peripheral Interrupt Handlers                                     */
+/* Add here the Interrupt Handlers for the used peripherals.                  */
+/* For the available peripheral interrupt handler names,                      */
+/* please refer to the startup file.                                          */
+/******************************************************************************/
+
+/************************ (C) COPYRIGHT Puya *****END OF FILE******************/

--- a/Examples/HAL/I2C/PCF8574_I2C_LCD_F003_SOP16/py32f0xx_it.h
+++ b/Examples/HAL/I2C/PCF8574_I2C_LCD_F003_SOP16/py32f0xx_it.h
@@ -1,0 +1,48 @@
+/**
+  ******************************************************************************
+  * @file    py32f0xx_it.h
+  * @author  MCU Application Team
+  * @brief   This file contains the headers of the interrupt handlers.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) Puya Semiconductor Co.
+  * All rights reserved.</center></h2>
+  *
+  * <h2><center>&copy; Copyright (c) 2016 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __PY32F0XX_IT_H
+#define __PY32F0XX_IT_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Private includes ----------------------------------------------------------*/
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+/* Exported macro ------------------------------------------------------------*/
+/* Exported functions prototypes ---------------------------------------------*/
+void NMI_Handler(void);
+void HardFault_Handler(void);
+void SVC_Handler(void);
+void PendSV_Handler(void);
+void SysTick_Handler(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __PY32F0XX_IT_H */
+
+/************************ (C) COPYRIGHT Puya *****END OF FILE******************/


### PR DESCRIPTION
Related: https://github.com/IOsetting/py32f0-template/issues/3.

These examples were tested with `PY32F030F28P6TU TSSOP20` chip and `PY32F003W16S6TU - SOP16` chip - they work well.

~~For some reason, this sample example does NOT work with `PY32F003W16S6TU - SOP16` chip even after making appropriate Makefile changes. Tips/hints to get this example working on ` PY32F003W16S6TU - SOP16` chip are welcome!~~

