### PR TITLE
feat: hal tim encoder example

### DIFF
--- a/Examples/HAL/TIM/TIM_ENCODER/README.md
+++ b/Examples/HAL/TIM/TIM_ENCODER/README.md
@@ -1,0 +1,33 @@
+Following `Makefile` changes are needed to run this example:
+
+```diff
+diff --git a/Makefile b/Makefile
+index 5c24b12..cca49c1 100644
+--- a/Makefile
++++ b/Makefile
+@@ -38,13 +38,13 @@ PYOCD_EXE           ?= pyocd
+ #   py32f003x4,  py32f003x6, py32f003x8,
+ #   py32f030x3,  py32f030x4, py32f030x6, py32f030x7, py32f030x8
+ #   py32f072xb
+-PYOCD_DEVICE   ?= py32f030x8
++PYOCD_DEVICE   ?= py32f003x6
+
+
+ ##### Paths ############
+
+ # Link descript file: py32f002x5.ld, py32f003x6.ld, py32f003x8.ld, py32f030x6.ld, py32f030x8.ld
+-LDSCRIPT               = Libraries/LDScripts/py32f030x8.ld
++LDSCRIPT               = Libraries/LDScripts/py32f003x6.ld
+ # Library build flags:
+ #   PY32F002x5, PY32F002Ax5,
+ #   PY32F003x4, PY32F003x6, PY32F003x8,
+@@ -61,7 +61,7 @@ CFILES :=
+ # ASM source folders
+ ADIRS  := User
+ # ASM single files
+-AFILES := Libraries/CMSIS/Device/PY32F0xx/Source/gcc/startup_py32f030.s
++AFILES := Libraries/CMSIS/Device/PY32F0xx/Source/gcc/startup_py32f003.s
+
+ # Include paths
+ INCLUDES       := Libraries/CMSIS/Core/Include \
+```

--- a/Examples/HAL/TIM/TIM_ENCODER/encoder.c
+++ b/Examples/HAL/TIM/TIM_ENCODER/encoder.c
@@ -1,0 +1,63 @@
+#include "encoder.h"
+
+TIM_HandleTypeDef htim3;
+
+static uint16_t newCount;
+static uint16_t prevCount;
+
+void Encoder_Init(void) {
+  HAL_TIM_Encoder_Start(&htim3, TIM_CHANNEL_ALL);
+}
+
+uint16_t Encoder_Read() {
+  uint16_t val = __HAL_TIM_GET_COUNTER(&htim3);
+  return val >> 1;
+}
+
+Encoder_Status Encoder_Get_Status() {
+  newCount = Encoder_Read();
+  if (newCount != prevCount) {
+    if (newCount > prevCount) {
+      prevCount = newCount;
+      return Incremented;
+    } else {
+      prevCount = newCount;
+      return Decremented;
+    }
+  }
+  return Neutral;
+}
+
+/**
+  * @brief TIM3 Initialization Function (Encoder Mode)
+  * @param None
+  * @retval None
+  */
+void Encoder_Config(void)
+{
+  TIM_Encoder_InitTypeDef sConfig = {0};
+  TIM_MasterConfigTypeDef sMasterConfig = {0};
+
+  htim3.Instance = TIM3;
+  htim3.Init.Prescaler = 0;
+  htim3.Init.CounterMode = TIM_COUNTERMODE_UP;
+  htim3.Init.Period = 65535;
+  htim3.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+  htim3.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+  sConfig.EncoderMode = TIM_ENCODERMODE_TI1;
+  sConfig.IC1Polarity = TIM_ICPOLARITY_RISING;
+  sConfig.IC1Selection = TIM_ICSELECTION_DIRECTTI;
+  sConfig.IC1Prescaler = TIM_ICPSC_DIV1; // Capture performed each time an edge is detected on the capture input
+  sConfig.IC1Filter = 0;
+  sConfig.IC2Polarity = TIM_ICPOLARITY_RISING;
+  sConfig.IC2Selection = TIM_ICSELECTION_DIRECTTI;
+  sConfig.IC2Prescaler = TIM_ICPSC_DIV1; // Capture performed each time an edge is detected on the capture input
+  sConfig.IC2Filter = 0;
+
+  HAL_TIM_Encoder_Init(&htim3, &sConfig);
+
+  sMasterConfig.MasterOutputTrigger = TIM_TRGO_RESET;
+  sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
+
+  HAL_TIMEx_MasterConfigSynchronization(&htim3, &sMasterConfig);
+}

--- a/Examples/HAL/TIM/TIM_ENCODER/encoder.h
+++ b/Examples/HAL/TIM/TIM_ENCODER/encoder.h
@@ -1,0 +1,38 @@
+#ifndef __ENCODER_H
+#define __ENCODER_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "py32f0xx_hal_def.h"
+#include "py32f0xx_hal_conf.h"
+
+#ifndef ENCODER_TIM
+#define ENCODER_TIM                            htim3
+#endif
+
+#ifndef ENCODER_GPIO_PORT
+#define ENCODER_GPIO_PORT                      GPIOA
+#endif
+#ifndef ENCODER_GPIO_CH1
+#define ENCODER_GPIO_CH1                       GPIO_PIN_6
+#endif
+
+#ifndef ENCODER_GPIO_CH2
+#define ENCODER_GPIO_CH2                       GPIO_PIN_7
+#endif
+
+extern TIM_HandleTypeDef htim3;
+
+typedef enum {
+  Incremented = 1,
+  Decremented = -1,
+  Neutral = 0,
+} Encoder_Status;
+
+
+void Encoder_Config(void);
+void Encoder_Init(void);
+uint16_t Encoder_Read();
+Encoder_Status Encoder_Get_Status();
+
+#endif

--- a/Examples/HAL/TIM/TIM_ENCODER/main.c
+++ b/Examples/HAL/TIM/TIM_ENCODER/main.c
@@ -1,0 +1,53 @@
+// This example was tested with 'PY32F003W16S6TU SOP16' chip
+
+#include "py32f0xx_hal_dma.h"
+#include "py32f0xx_bsp_printf.h"
+
+// https://github.com/scottc11/stm32-encoder
+#include "encoder.h"
+
+void APP_ErrorHandler(void);
+
+Encoder_Status encoderStatus;
+
+int main(void)
+{
+  HAL_Init();
+
+  BSP_USART_Config();
+  printf("SystemClk:%ld\r\n", SystemCoreClock);
+
+  Encoder_Config(); // configure the encoder's timer
+  Encoder_Init(); // start the encoder's timer
+
+  while(1) {
+    encoderStatus = Encoder_Get_Status();
+
+    switch(encoderStatus) {
+      case Incremented:
+        printf("Incremented\n");
+        break;
+      case Decremented:
+        printf("Decremented\n");
+        break;
+      case Neutral:
+        break;
+    }
+  }
+}
+
+void APP_ErrorHandler(void)
+{
+  while (1);
+}
+
+#ifdef  USE_FULL_ASSERT
+/**
+  * @brief  Export assert error source and line number
+  */
+void assert_failed(uint8_t *file, uint32_t line)
+{
+  /* printf("Wrong parameters value: file %s on line %d\r\n", file, line) */
+  while (1);
+}
+#endif /* USE_FULL_ASSERT */

--- a/Examples/HAL/TIM/TIM_ENCODER/py32f0xx_hal_conf.h
+++ b/Examples/HAL/TIM/TIM_ENCODER/py32f0xx_hal_conf.h
@@ -1,0 +1,229 @@
+/**
+  ******************************************************************************
+  * @file    py32f0xx_hal_conf.h
+  * @author  MCU Application Team
+  * @brief   HAL configuration file.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) Puya Semiconductor Co.
+  * All rights reserved.</center></h2>
+  *
+  * <h2><center>&copy; Copyright (c) 2016 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __PY32F0xx_HAL_CONF_H
+#define __PY32F0xx_HAL_CONF_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+
+/* ########################## Module Selection ############################## */
+/**
+  * @brief This is the list of modules to be used in the HAL driver
+  */
+#define HAL_MODULE_ENABLED
+#define HAL_RCC_MODULE_ENABLED
+/* #define HAL_ADC_MODULE_ENABLED */
+/* #define HAL_CRC_MODULE_ENABLED */
+/* #define HAL_COMP_MODULE_ENABLED */
+#define HAL_FLASH_MODULE_ENABLED
+#define HAL_GPIO_MODULE_ENABLED
+/* #define HAL_IWDG_MODULE_ENABLED */
+/* #define HAL_WWDG_MODULE_ENABLED */
+#define HAL_TIM_MODULE_ENABLED
+#define HAL_DMA_MODULE_ENABLED
+/* #define HAL_LPTIM_MODULE_ENABLED */
+#define HAL_PWR_MODULE_ENABLED
+// #define HAL_I2C_MODULE_ENABLED
+#define HAL_UART_MODULE_ENABLED
+/* #define HAL_SPI_MODULE_ENABLED */
+/* #define HAL_RTC_MODULE_ENABLED */
+/* #define HAL_LED_MODULE_ENABLED */
+/* #define HAL_EXTI_MODULE_ENABLED */
+#define HAL_CORTEX_MODULE_ENABLED
+
+/* ########################## Oscillator Values adaptation ####################*/
+
+#if !defined  (HSI_VALUE)
+  #define HSI_VALUE              ((uint32_t)8000000)     /*!< Value of the Internal oscillator in Hz */
+#endif /* HSI_VALUE */
+
+/**
+  * @brief Adjust the value of External High Speed oscillator (HSE) used in your application.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  */
+#if !defined  (HSE_VALUE)
+  #define HSE_VALUE              ((uint32_t)24000000) /*!< Value of the External oscillator in Hz */
+#endif /* HSE_VALUE */
+
+#if !defined  (HSE_STARTUP_TIMEOUT)
+  #define HSE_STARTUP_TIMEOUT    ((uint32_t)200)   /*!< Time out for HSE start up, in ms */
+#endif /* HSE_STARTUP_TIMEOUT */
+
+/**
+  * @brief Internal Low Speed Internal oscillator (LSI) value.
+  */
+#if !defined  (LSI_VALUE)
+ #define LSI_VALUE               ((uint32_t)32768)    /*!< LSI Typical Value in Hz */
+#endif /* LSI_VALUE */                               /*!< Value of the Internal Low Speed oscillator in Hz
+                                                     The real value may vary depending on the variations
+                                                     in voltage and temperature. */
+
+/**
+  * @brief Adjust the value of External Low Speed oscillator (LSE) used in your application.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  */
+#if !defined  (LSE_VALUE)
+  #define LSE_VALUE              ((uint32_t)32768) /*!< Value of the External oscillator in Hz*/
+#endif /* LSE_VALUE */
+
+#if !defined  (LSE_STARTUP_TIMEOUT)
+  #define LSE_STARTUP_TIMEOUT    ((uint32_t)5000)   /*!< Time out for LSE start up, in ms */
+#endif /* LSE_STARTUP_TIMEOUT */
+
+/* Tip: To avoid modifying this file each time you need to use different HSE,
+   ===  you can define the HSE value in your toolchain compiler preprocessor. */
+
+/* ########################### System Configuration ######################### */
+/**
+  * @brief This is the HAL system configuration section
+  */
+#define  VDD_VALUE               ((uint32_t)3300) /*!< Value of VDD in mv */
+#define  PRIORITY_HIGHEST        0
+#define  PRIORITY_HIGH           1
+#define  PRIORITY_LOW            2
+#define  PRIORITY_LOWEST         3
+#define  TICK_INT_PRIORITY       ((uint32_t)PRIORITY_LOWEST)    /*!< tick interrupt priority (lowest by default)  */
+#define  USE_RTOS                0
+#define  PREFETCH_ENABLE         0
+
+/* ########################## Assert Selection ############################## */
+/**
+  * @brief Uncomment the line below to expanse the "assert_param" macro in the
+  *        HAL drivers code
+  */
+/* #define USE_FULL_ASSERT       1U */
+
+
+/* Includes ------------------------------------------------------------------*/
+/**
+  * @brief Include module's header file
+  */
+#ifdef HAL_MODULE_ENABLED
+ #include "py32f0xx_hal.h"
+#endif /* HAL_MODULE_ENABLED */
+
+#ifdef HAL_RCC_MODULE_ENABLED
+ #include "py32f0xx_hal_rcc.h"
+#endif /* HAL_RCC_MODULE_ENABLED */
+
+#ifdef HAL_EXTI_MODULE_ENABLED
+ #include "py32f0xx_hal_exti.h"
+#endif /* HAL_EXTI_MODULE_ENABLED */
+
+#ifdef HAL_GPIO_MODULE_ENABLED
+ #include "py32f0xx_hal_gpio.h"
+#endif /* HAL_GPIO_MODULE_ENABLED */
+
+#ifdef HAL_CORTEX_MODULE_ENABLED
+ #include "py32f0xx_hal_cortex.h"
+#endif /* HAL_CORTEX_MODULE_ENABLED */
+
+#ifdef HAL_DMA_MODULE_ENABLED
+  #include "py32f0xx_hal_dma.h"
+#endif /* HAL_DMA_MODULE_ENABLED */
+
+#ifdef HAL_ADC_MODULE_ENABLED
+ #include "py32f0xx_hal_adc.h"
+#endif /* HAL_ADC_MODULE_ENABLED */
+
+#ifdef HAL_CRC_MODULE_ENABLED
+ #include "py32f0xx_hal_crc.h"
+#endif /* HAL_CRC_MODULE_ENABLED */
+
+#ifdef HAL_COMP_MODULE_ENABLED
+#include "py32f0xx_hal_comp.h"
+#endif /* HAL_COMP_MODULE_ENABLED */
+
+#ifdef HAL_FLASH_MODULE_ENABLED
+ #include "py32f0xx_hal_flash.h"
+#endif /* HAL_FLASH_MODULE_ENABLED */
+
+#ifdef HAL_I2C_MODULE_ENABLED
+ #include "py32f0xx_hal_i2c.h"
+#endif /* HAL_I2C_MODULE_ENABLED */
+
+#ifdef HAL_IWDG_MODULE_ENABLED
+ #include "py32f0xx_hal_iwdg.h"
+#endif /* HAL_IWDG_MODULE_ENABLED */
+
+#ifdef HAL_PWR_MODULE_ENABLED
+ #include "py32f0xx_hal_pwr.h"
+#endif /* HAL_PWR_MODULE_ENABLED */
+
+#ifdef HAL_RTC_MODULE_ENABLED
+ #include "py32f0xx_hal_rtc.h"
+#endif /* HAL_RTC_MODULE_ENABLED */
+
+#ifdef HAL_SPI_MODULE_ENABLED
+ #include "py32f0xx_hal_spi.h"
+#endif /* HAL_SPI_MODULE_ENABLED */
+
+#ifdef HAL_TIM_MODULE_ENABLED
+ #include "py32f0xx_hal_tim.h"
+#endif /* HAL_TIM_MODULE_ENABLED */
+
+#ifdef HAL_LPTIM_MODULE_ENABLED
+ #include "py32f0xx_hal_lptim.h"
+#endif /* HAL_LPTIM_MODULE_ENABLED */
+
+#ifdef HAL_UART_MODULE_ENABLED
+ #include "py32f0xx_hal_uart.h"
+#endif /* HAL_UART_MODULE_ENABLED */
+
+#ifdef HAL_WWDG_MODULE_ENABLED
+ #include "py32f0xx_hal_wwdg.h"
+#endif /* HAL_WWDG_MODULE_ENABLED */
+
+#ifdef HAL_USART_MODULE_ENABLED
+ #include "py32f0xx_hal_usart.h"
+#endif /* HAL_USART_MODULE_ENABLED */
+
+/* Exported macro ------------------------------------------------------------*/
+#ifdef  USE_FULL_ASSERT
+/**
+  * @brief  The assert_param macro is used for function's parameters check.
+  * @param  expr: If expr is false, it calls assert_failed function
+  *         which reports the name of the source file and the source
+  *         line number of the call that failed.
+  *         If expr is true, it returns no value.
+  * @retval None
+  */
+  #define assert_param(expr) ((expr) ? (void)0U : assert_failed((uint8_t *)__FILE__, __LINE__))
+/* Exported functions ------------------------------------------------------- */
+  void assert_failed(uint8_t* file, uint32_t line);
+#else
+  #define assert_param(expr) ((void)0U)
+#endif /* USE_FULL_ASSERT */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __PY32F0xx_HAL_CONF_H */
+
+/************************ (C) COPYRIGHT Puya *****END OF FILE******************/

--- a/Examples/HAL/TIM/TIM_ENCODER/py32f0xx_hal_msp.c
+++ b/Examples/HAL/TIM/TIM_ENCODER/py32f0xx_hal_msp.c
@@ -1,0 +1,67 @@
+/**
+  ******************************************************************************
+  * @file    py32f0xx_hal_msp.c
+  * @author  MCU Application Team
+  * @brief   This file provides code for the MSP Initialization
+  *          and de-Initialization codes.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) Puya Semiconductor Co.
+  * All rights reserved.</center></h2>
+  *
+  * <h2><center>&copy; Copyright (c) 2016 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdlib.h>
+#include "py32f0xx_hal.h"
+#include "encoder.h"
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* External functions --------------------------------------------------------*/
+
+/**
+  * @brief  Configure the Flash prefetch and the Instruction cache,
+  *         the time base source, NVIC and any required global low level hardware
+  *         by calling the HAL_MspInit() callback function from HAL_Init()
+  *
+  */
+void HAL_MspInit(void)
+{
+}
+
+/**
+* @brief TIM_Encoder MSP Initialization
+* This function configures the hardware resources used in this example
+* @param htim_encoder: TIM_Encoder handle pointer
+* @retval None
+*/
+void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef* htim_encoder)
+{
+  GPIO_InitTypeDef GPIO_InitStruct = {0};
+  if(htim_encoder->Instance==TIM3)
+  {
+    __HAL_RCC_TIM3_CLK_ENABLE();
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+    GPIO_InitStruct.Pin = ENCODER_GPIO_CH1|ENCODER_GPIO_CH2;
+    GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
+    GPIO_InitStruct.Pull = GPIO_PULLUP;
+    GPIO_InitStruct.Alternate = GPIO_AF1_TIM3;
+    HAL_GPIO_Init(ENCODER_GPIO_PORT, &GPIO_InitStruct);
+  }
+}
+
+/************************ (C) COPYRIGHT Puya *****END OF FILE******************/

--- a/Examples/HAL/TIM/TIM_ENCODER/py32f0xx_it.c
+++ b/Examples/HAL/TIM/TIM_ENCODER/py32f0xx_it.c
@@ -1,0 +1,85 @@
+/**
+  ******************************************************************************
+  * @file    py32f0xx_it.c
+  * @author  MCU Application Team
+  * @brief   Interrupt Service Routines.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) Puya Semiconductor Co.
+  * All rights reserved.</center></h2>
+  *
+  * <h2><center>&copy; Copyright (c) 2016 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "py32f0xx_hal.h"
+#include "py32f0xx_it.h"
+
+/* Private includes ----------------------------------------------------------*/
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private user code ---------------------------------------------------------*/
+/* External variables --------------------------------------------------------*/
+
+/******************************************************************************/
+/*          Cortex-M0+ Processor Interruption and Exception Handlers          */
+/******************************************************************************/
+/**
+  * @brief This function handles Non maskable interrupt.
+  */
+void NMI_Handler(void)
+{
+}
+
+/**
+  * @brief This function handles Hard fault interrupt.
+  */
+void HardFault_Handler(void)
+{
+  while (1)
+  {
+  }
+}
+
+/**
+  * @brief This function handles System service call via SWI instruction.
+  */
+void SVC_Handler(void)
+{
+}
+
+/**
+  * @brief This function handles Pendable request for system service.
+  */
+void PendSV_Handler(void)
+{
+}
+
+/**
+  * @brief This function handles System tick timer.
+  */
+void SysTick_Handler(void)
+{
+  HAL_IncTick();
+}
+
+/******************************************************************************/
+/* PY32F0xx Peripheral Interrupt Handlers                                     */
+/* Add here the Interrupt Handlers for the used peripherals.                  */
+/* For the available peripheral interrupt handler names,                      */
+/* please refer to the startup file.                                          */
+/******************************************************************************/
+
+/************************ (C) COPYRIGHT Puya *****END OF FILE******************/

--- a/Examples/HAL/TIM/TIM_ENCODER/py32f0xx_it.h
+++ b/Examples/HAL/TIM/TIM_ENCODER/py32f0xx_it.h
@@ -1,0 +1,48 @@
+/**
+  ******************************************************************************
+  * @file    py32f0xx_it.h
+  * @author  MCU Application Team
+  * @brief   This file contains the headers of the interrupt handlers.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) Puya Semiconductor Co.
+  * All rights reserved.</center></h2>
+  *
+  * <h2><center>&copy; Copyright (c) 2016 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __PY32F0XX_IT_H
+#define __PY32F0XX_IT_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Private includes ----------------------------------------------------------*/
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+/* Exported macro ------------------------------------------------------------*/
+/* Exported functions prototypes ---------------------------------------------*/
+void NMI_Handler(void);
+void HardFault_Handler(void);
+void SVC_Handler(void);
+void PendSV_Handler(void);
+void SysTick_Handler(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __PY32F0XX_IT_H */
+
+/************************ (C) COPYRIGHT Puya *****END OF FILE******************/


### PR DESCRIPTION
This pull request adds a basic example to interact with `Rotary encoder module (KY-40)`.

This example was tested with `PY32F003W16S6TU SOP16` chip.

Testing notes:

```
$ pyserial-miniterm /dev/ttyUSB0 115200
--- Miniterm on /dev/ttyUSB0  115200,8,N,1 ---
--- Quit: Ctrl+] | Menu: Ctrl+T | Help: Ctrl+T followed by Ctrl+H ---
SystemClk:8000000
Incremented
Decremented
Incremented
Decremented
Incremented
Decremented
Decremented
Decremented
Decremented
```

The `Encoder Library` code is borrowed from https://github.com/scottc11/stm32-encoder project.