### PR TITLE
Add py32f003x4 ld script

### DIFF
--- a/Libraries/LDScripts/py32f003x4.ld
+++ b/Libraries/LDScripts/py32f003x4.ld
@@ -3,7 +3,7 @@
 **
 **  File        : LinkerScript.ld
 **
-**  Abstract    : Linker script for PY32F003x6 series
+**  Abstract    : Linker script for PY32F003x4 series
 **                Set heap size, stack size and stack location according
 **                to application requirements.
 **                Set memory bank area and size if external memory is used.

--- a/Libraries/LDScripts/py32f003x4.ld
+++ b/Libraries/LDScripts/py32f003x4.ld
@@ -1,0 +1,163 @@
+/*
+******************************************************************************
+**
+**  File        : LinkerScript.ld
+**
+**  Abstract    : Linker script for PY32F003x6 series
+**                Set heap size, stack size and stack location according
+**                to application requirements.
+**                Set memory bank area and size if external memory is used.
+**
+**  Distribution: The file is distributed “as is,” without any warranty
+**                of any kind.
+**
+*****************************************************************************
+*/
+
+/* Entry Point */
+ENTRY(Reset_Handler)
+
+/* Highest address of the user mode stack */
+_estack = ORIGIN(RAM) + LENGTH(RAM);    /* end of RAM */
+/*
+  Generate a link error if heap and stack don't fit into RAM.
+  These numbers affect the USED size of RAM
+  Note: reserve 1K of ram for statics/globals 
+*/
+_Min_Heap_Size = 0x200;   /* required amount of heap: 512 bytes */
+_Min_Stack_Size = 0x200;  /* required amount of stack: 512 bytes */
+
+
+/* Specify the memory areas */
+MEMORY
+{
+  RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 2K
+  FLASH (rx)     : ORIGIN = 0x08000000, LENGTH = 16K
+}
+
+/* Define output sections */
+SECTIONS
+{
+  /* SRAM vector table */
+  .ram_vector :
+  {
+    *(.ram_vector)
+  } >RAM
+
+  /* The startup code goes first into FLASH */
+  .isr_vector :
+  {
+    . = ALIGN(4);
+    KEEP(*(.isr_vector)) /* Startup code */
+    . = ALIGN(4);
+  } >FLASH
+
+  /* The program code and other data goes into FLASH */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)           /* .text sections (code) */
+    *(.text*)          /* .text* sections (code) */
+    *(.glue_7)         /* glue arm to thumb code */
+    *(.glue_7t)        /* glue thumb to arm code */
+    *(.eh_frame)
+
+    KEEP (*(.init))
+    KEEP (*(.fini))
+
+    . = ALIGN(4);
+    _etext = .;        /* define a global symbols at end of code */
+  } >FLASH
+
+  /* Constant data goes into FLASH */
+  .rodata :
+  {
+    . = ALIGN(4);
+    *(.rodata)         /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
+    . = ALIGN(4);
+  } >FLASH
+
+  .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >FLASH
+  .ARM : {
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+  } >FLASH
+
+  .preinit_array     :
+  {
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+  } >FLASH
+  .init_array :
+  {
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array*))
+    PROVIDE_HIDDEN (__init_array_end = .);
+  } >FLASH
+  .fini_array :
+  {
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT(.fini_array.*)))
+    KEEP (*(.fini_array*))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+  } >FLASH
+
+  /* used by the startup to initialize data */
+  _sidata = LOADADDR(.data);
+
+  /* Initialized data sections goes into RAM, load LMA copy after code */
+  .data : 
+  {
+    . = ALIGN(4);
+    _sdata = .;        /* create a global symbol at data start */
+    *(.data)           /* .data sections */
+    *(.data*)          /* .data* sections */
+
+    . = ALIGN(4);
+    _edata = .;        /* define a global symbol at data end */
+  } >RAM AT> FLASH
+
+  
+  /* Uninitialized data section */
+  . = ALIGN(4);
+  .bss :
+  {
+    /* This is used by the startup in order to initialize the .bss secion */
+    _sbss = .;         /* define a global symbol at bss start */
+    __bss_start__ = _sbss;
+    *(.bss)
+    *(.bss*)
+    *(COMMON)
+
+    . = ALIGN(4);
+    _ebss = .;         /* define a global symbol at bss end */
+    __bss_end__ = _ebss;
+  } >RAM
+
+  /* User_heap_stack section, used to check that there is enough RAM left */
+  ._user_heap_stack :
+  {
+    . = ALIGN(8);
+    PROVIDE ( end = . );
+    PROVIDE ( _end = . );
+    . = . + _Min_Heap_Size;
+    . = . + _Min_Stack_Size;
+    . = ALIGN(8);
+  } >RAM
+
+  /* Remove information from the standard libraries */
+  /DISCARD/ :
+  {
+    libc.a ( * )
+    libm.a ( * )
+    libgcc.a ( * )
+  }
+
+  .ARM.attributes 0 : { *(.ARM.attributes) }
+}
+
+

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ BUILD_DIR		= Build
 # MCU types: 
 #   PY32F002Ax5
 #   PY32F002Bx5
-#   PY32F003x6, PY32F003x8, 
+#   PY32F003x4, PY32F003x6, PY32F003x8,
 #   PY32F030x6, PY32F030x8, 
 #   PY32F072xB
-MCU_TYPE		= PY32F030x8
+MCU_TYPE		= PY32F003x4
 
 ##### Options #####
 
@@ -31,7 +31,7 @@ FLASH_PROGRM	?= pyocd
 
 #ARM_TOOCHAIN	?= /opt/gcc-arm/gcc-arm-11.2-2022.02-x86_64-arm-none-eabi/bin
 #ARM_TOOCHAIN	?= /opt/gcc-arm/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi/bin
-ARM_TOOCHAIN	?= /opt/gcc-arm/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi/bin
+ARM_TOOCHAIN	?= /opt/gcc-arm/arm-gnu-toolchain-13.2.Rel1-x86_64-arm-none-eabi/bin
 
 # path to JLinkExe
 JLINKEXE		?= /opt/SEGGER/JLink/JLinkExe


### PR DESCRIPTION
feat: add ld script for PY32F0003x4 variant with 16K flash and 2K ram

-reduced  _Min_Heap_Size and _Min_Stack_Size to fit with default makefile build
-modified RAM and FLASH according to datasheet spec
-add PY32F0003x4 option to Makefile