### PR TITLE
Fix LL_RCC_HSI_SetCalibFreq not updating SystemCoreClock variable when changing HSI frequency

### DIFF
--- a/Libraries/PY32F002B_LL_Driver/Inc/py32f002b_ll_rcc.h
+++ b/Libraries/PY32F002B_LL_Driver/Inc/py32f002b_ll_rcc.h
@@ -560,6 +560,7 @@ __STATIC_INLINE uint32_t LL_RCC_HSI_GetCalibTrimming(void)
 __STATIC_INLINE void LL_RCC_HSI_SetCalibFreq(uint32_t Value)
 {
   MODIFY_REG(RCC->ICSCR, (RCC_ICSCR_HSI_FS | RCC_ICSCR_HSI_TRIM), (Value << RCC_ICSCR_HSI_TRIM_Pos));
+  SystemCoreClockUpdate();
 }
 
 /**

--- a/Libraries/PY32F0xx_LL_Driver/Inc/py32f0xx_ll_rcc.h
+++ b/Libraries/PY32F0xx_LL_Driver/Inc/py32f0xx_ll_rcc.h
@@ -724,6 +724,7 @@ __STATIC_INLINE uint32_t LL_RCC_HSI_GetCalibTrimming(void)
 __STATIC_INLINE void LL_RCC_HSI_SetCalibFreq(uint32_t Value)
 {
   MODIFY_REG(RCC->ICSCR, (RCC_ICSCR_HSI_FS | RCC_ICSCR_HSI_TRIM), Value);
+  SystemCoreClockUpdate();
 }
 
 /**


### PR DESCRIPTION
LL_RCC_HSI_SetCalibFreq would never update this value, so SystemCoreClock was always 8MHz.