### PR TITLE
Clean up ARM_TOOLCHAIN

### DIFF
--- a/Examples/PY32F0xx/LL/SPI/nRF24L01_Wireless_F003_SOP16/Makefile
+++ b/Examples/PY32F0xx/LL/SPI/nRF24L01_Wireless_F003_SOP16/Makefile
@@ -22,9 +22,7 @@ FLASH_PROGRM	?= jlink
 
 ##### Toolchains #######
 
-#ARM_TOOCHAIN	?= /opt/gcc-arm/gcc-arm-11.2-2022.02-x86_64-arm-none-eabi/bin
-#ARM_TOOCHAIN	?= /opt/gcc-arm/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi/bin
-ARM_TOOCHAIN	?= /opt/gcc-arm/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi/bin
+ARM_TOOLCHAIN	?= /usr/bin
 
 # path to JLinkExe
 JLINKEXE		?= /opt/SEGGER/JLink/JLinkExe

--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,7 @@ FLASH_PROGRM	?= pyocd
 
 ##### Toolchains #######
 
-#ARM_TOOCHAIN	?= /opt/gcc-arm/gcc-arm-11.2-2022.02-x86_64-arm-none-eabi/bin
-#ARM_TOOCHAIN	?= /opt/gcc-arm/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi/bin
-ARM_TOOCHAIN	?= /opt/gcc-arm/arm-gnu-toolchain-13.2.Rel1-x86_64-arm-none-eabi/bin
+ARM_TOOLCHAIN	?= /usr/bin
 
 # path to JLinkExe
 JLINKEXE		?= /opt/SEGGER/JLink/JLinkExe

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Change the settings in Makefile
   * If you use J-Link, `FLASH_PROGRM` can be jlink or pyocd
   * If you use DAPLink, set `FLASH_PROGRM ?= pyocd`
   * ST-LINK is not supported yet.
-* **ARM_TOOCHAIN** Make sure it points to the correct path of arm-none-eabi-gcc
+* **ARM_TOOLCHAIN** Make sure it points to the correct path of arm-none-eabi-gcc
 
 ```makefile
 ##### Project #####
@@ -195,7 +195,7 @@ USE_DSP           ?= n
 FLASH_PROGRM      ?= pyocd
 
 ##### Toolchains #######
-ARM_TOOCHAIN      ?= /opt/gcc-arm/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi/bin
+ARM_TOOLCHAIN     ?= /usr/bin
 
 # path to JLinkExe
 JLINKEXE		?= /opt/SEGGER/JLink/JLinkExe

--- a/rules.mk
+++ b/rules.mk
@@ -5,7 +5,7 @@ Q		:= @
 NULL	:= 2>/dev/null
 endif
 
-PREFIX		?= $(ARM_TOOCHAIN)/arm-none-eabi-
+PREFIX		?= $(ARM_TOOLCHAIN)/arm-none-eabi-
 CC			= $(PREFIX)gcc
 XX			= $(PREFIX)g++
 AS			= $(PREFIX)as


### PR DESCRIPTION
Rename `ARM_TOOCHAIN` to `ARM_TOOLCHAIN` and use a sensible default. On Ubuntu (and possibly other Debian-like distros), the ARM toolchain can be installed with the distro's package manager in `/usr/bin`, so it makes more sense to use that as a default instead of some very specific path name in `/opt`.