### PR TITLE
Inline LL_Init1msTick to omit division code

### DIFF
--- a/Libraries/PY32F002B_LL_Driver/Inc/py32f002b_ll_utils.h
+++ b/Libraries/PY32F002B_LL_Driver/Inc/py32f002b_ll_utils.h
@@ -208,7 +208,20 @@ __STATIC_INLINE void LL_InitTick(uint32_t HCLKFrequency, uint32_t Ticks)
                    SysTick_CTRL_ENABLE_Msk;                   /* Enable the Systick Timer */
 }
 
-void        LL_Init1msTick(uint32_t HCLKFrequency);
+/**
+  * @brief  This function configures the Cortex-M SysTick source to have 1ms time base.
+  * @note   When a RTOS is used, it is recommended to avoid changing the Systick
+  *         configuration by calling this function, for a delay use rather osDelay RTOS service.
+  * @param  HCLKFrequency HCLK frequency in Hz
+  * @note   HCLK frequency can be calculated thanks to RCC helper macro or function @ref LL_RCC_GetSystemClocksFreq
+  * @retval None
+  */
+__STATIC_INLINE void LL_Init1msTick(uint32_t HCLKFrequency)
+{
+  /* Use frequency provided in argument */
+  LL_InitTick(HCLKFrequency, 1000U);
+}
+
 void        LL_mDelay(uint32_t Delay);
 
 /**

--- a/Libraries/PY32F002B_LL_Driver/Src/py32f002b_ll_utils.c
+++ b/Libraries/PY32F002B_LL_Driver/Src/py32f002b_ll_utils.c
@@ -90,20 +90,6 @@
   */
 
 /**
-  * @brief  This function configures the Cortex-M SysTick source to have 1ms time base.
-  * @note   When a RTOS is used, it is recommended to avoid changing the Systick
-  *         configuration by calling this function, for a delay use rather osDelay RTOS service.
-  * @param  HCLKFrequency HCLK frequency in Hz
-  * @note   HCLK frequency can be calculated thanks to RCC helper macro or function @ref LL_RCC_GetSystemClocksFreq
-  * @retval None
-  */
-void LL_Init1msTick(uint32_t HCLKFrequency)
-{
-  /* Use frequency provided in argument */
-  LL_InitTick(HCLKFrequency, 1000U);
-}
-
-/**
   * @brief  This function provides accurate delay (in milliseconds) based
   *         on SysTick counter flag
   * @note   When a RTOS is used, it is recommended to avoid using blocking delay

--- a/Libraries/PY32F0xx_LL_Driver/Inc/py32f0xx_ll_utils.h
+++ b/Libraries/PY32F0xx_LL_Driver/Inc/py32f0xx_ll_utils.h
@@ -208,7 +208,20 @@ __STATIC_INLINE void LL_InitTick(uint32_t HCLKFrequency, uint32_t Ticks)
                    SysTick_CTRL_ENABLE_Msk;                   /* Enable the Systick Timer */
 }
 
-void        LL_Init1msTick(uint32_t HCLKFrequency);
+/**
+  * @brief  This function configures the Cortex-M SysTick source to have 1ms time base.
+  * @note   When a RTOS is used, it is recommended to avoid changing the Systick
+  *         configuration by calling this function, for a delay use rather osDelay RTOS service.
+  * @param  HCLKFrequency HCLK frequency in Hz
+  * @note   HCLK frequency can be calculated thanks to RCC helper macro or function @ref LL_RCC_GetSystemClocksFreq
+  * @retval None
+  */
+__STATIC_INLINE void LL_Init1msTick(uint32_t HCLKFrequency)
+{
+  /* Use frequency provided in argument */
+  LL_InitTick(HCLKFrequency, 1000U);
+}
+
 void        LL_mDelay(uint32_t Delay);
 
 /**

--- a/Libraries/PY32F0xx_LL_Driver/Src/py32f0xx_ll_utils.c
+++ b/Libraries/PY32F0xx_LL_Driver/Src/py32f0xx_ll_utils.c
@@ -115,20 +115,6 @@
   */
 
 /**
-  * @brief  This function configures the Cortex-M SysTick source to have 1ms time base.
-  * @note   When a RTOS is used, it is recommended to avoid changing the Systick
-  *         configuration by calling this function, for a delay use rather osDelay RTOS service.
-  * @param  HCLKFrequency HCLK frequency in Hz
-  * @note   HCLK frequency can be calculated thanks to RCC helper macro or function @ref LL_RCC_GetSystemClocksFreq
-  * @retval None
-  */
-void LL_Init1msTick(uint32_t HCLKFrequency)
-{
-  /* Use frequency provided in argument */
-  LL_InitTick(HCLKFrequency, 1000U);
-}
-
-/**
   * @brief  This function provides accurate delay (in milliseconds) based
   *         on SysTick counter flag
   * @note   When a RTOS is used, it is recommended to avoid using blocking delay


### PR DESCRIPTION
Reduce flash footprint by inlining `LL_Init1msTick` so that the SysTick LOAD register value can be calculated by the compiler, if constant frequency values are used.

Code size for Examples/PY32F002B/LL/GPIO/GPIO_Toggle

Before:
```
Memory region         Used Size  Region Size  %age Used
             RAM:         800 B         3 KB     26.04%
           FLASH:        1144 B        24 KB      4.65%
```

After:
```
Memory region         Used Size  Region Size  %age Used
             RAM:         800 B         3 KB     26.04%
           FLASH:         852 B        24 KB      3.47%
```